### PR TITLE
Added fullName and fixed parsing for Suffix to handle both DBS and DCU

### DIFF
--- a/DLParser/src/main/java/com/ajohnson/dlparserkotlin/models/FieldKey.kt
+++ b/DLParser/src/main/java/com/ajohnson/dlparserkotlin/models/FieldKey.kt
@@ -16,6 +16,7 @@ internal enum class FieldKey {
     GIVEN_NAME_ALIAS,
     SUFFIX_ALIAS,
     SUFFIX,
+    SUFFIX_2,
 
     MIDDLE_NAME_TRUNCATION,
     FIRST_NAME_TRUNCATION,

--- a/DLParser/src/main/java/com/ajohnson/dlparserkotlin/models/License.kt
+++ b/DLParser/src/main/java/com/ajohnson/dlparserkotlin/models/License.kt
@@ -7,6 +7,7 @@ import java.util.*
  * A model for storing the parsed license data.
  * */
 data class License(
+    var fullName: String? = null,
     var firstName: String? = null,
     var middleNames: List<String> = listOf(),
     var lastName: String? = null,


### PR DESCRIPTION
- Added a `fullName` field to the `License` model.
- Added handling for `parsedNameSuffix` to attempt to grab value from "DCU" field